### PR TITLE
Add docs to all settlement and lockup epochs 

### DIFF
--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -12,6 +12,8 @@ import "./RateChangeQueue.sol";
 interface IArbiter {
     struct ArbitrationResult {
         uint256 modifiedAmount;
+        // The epoch up to and including which settlement should occur.
+        // This is used to indicate how far the arbitration has settled the payment.
         uint256 settleUpto;
         string note;
     }
@@ -19,7 +21,9 @@ interface IArbiter {
     function arbitratePayment(
         uint256 railId,
         uint256 proposedAmount,
+        // the epoch up to and including which the rail has already been settled
         uint256 fromEpoch,
+        // the epoch up to which arbitration is requested; payment will be arbitrated for (toEpoch - fromEpoch) epochs
         uint256 toEpoch
     ) external returns (ArbitrationResult memory result);
 }
@@ -37,6 +41,7 @@ contract Payments is
         uint256 funds;
         uint256 lockupCurrent;
         uint256 lockupRate;
+        // The epoch up to and including which lockup has been settled for the account
         uint256 lockupLastSettledAt;
     }
 
@@ -50,6 +55,7 @@ contract Payments is
         uint256 paymentRate;
         uint256 lockupPeriod;
         uint256 lockupFixed;
+        // The epoch up to and including which this rail has been settled
         uint256 settledUpTo;
         RateChangeQueue.Queue rateChangeQueue;
         bool isLocked; // Indicates if the rail is currently being modified
@@ -326,6 +332,9 @@ contract Payments is
                 "not able to settle rail upto current epoch"
             );
         } else {
+            // For arbitrated rails, we need to enqueue the old rate.
+            // This ensures that the old rate is applied up to and including the current block.
+            // The new rate will be applicable starting from the next block.
             rail.rateChangeQueue.enqueue(rail.paymentRate, block.number);
         }
 

--- a/src/RateChangeQueue.sol
+++ b/src/RateChangeQueue.sol
@@ -3,7 +3,9 @@ pragma solidity ^0.8.20;
 
 library RateChangeQueue {
     struct RateChange {
+        // The payment rate to apply
         uint256 rate;
+        // The epoch up to and including which this rate will be used to settle a rail
         uint256 untilEpoch;
     }
 
@@ -14,7 +16,11 @@ library RateChangeQueue {
         uint256 tail;
     }
 
-    function enqueue(Queue storage queue, uint256 rate, uint256 untilEpoch) internal {
+    function enqueue(
+        Queue storage queue,
+        uint256 rate,
+        uint256 untilEpoch
+    ) internal {
         queue.changes[queue.tail] = RateChange(rate, untilEpoch);
         queue.tail++;
     }
@@ -27,7 +33,9 @@ library RateChangeQueue {
         return change;
     }
 
-    function peek(Queue storage queue) internal view returns (RateChange memory) {
+    function peek(
+        Queue storage queue
+    ) internal view returns (RateChange memory) {
         require(queue.head < queue.tail, "Queue is empty");
         return queue.changes[queue.head];
     }


### PR DESCRIPTION
Added docs to make it easy to reason about the absence of off by one errors in settlement, lockup and arbitration.