### PR TITLE
feat: enable rail terminate and allow operator to reduce rail rate if rail is not in debt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,4 @@ build:
 # Test target
 .PHONY: test
 test:
-	forge test -vv
+	forge test -vv --via-ir

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ install:
 # Build target
 .PHONY: build
 build:
-	forge build
+	forge build --via-ir
 
 # Test target
 .PHONY: test

--- a/foundry.toml
+++ b/foundry.toml
@@ -6,6 +6,7 @@ out = 'out'
 libs = ['lib']
 cache_path = 'cache'
 solc = "0.8.23"
+via_ir = true
 
 # For dependencies
 remappings = [

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -591,8 +591,7 @@ contract Payments is
     ) internal view {
         if (isRailTerminated(rail)) {
             require(
-                block.number <=
-                    maxSettlementEpochForTerminatedRail(rail),
+                block.number <= maxSettlementEpochForTerminatedRail(rail),
                 "terminated rail is beyond it's max settlement epoch; settle the rail"
             );
             require(
@@ -832,8 +831,7 @@ contract Payments is
         // Check if rail is a terminated rail that's now fully settled
         if (
             isRailTerminated(rail) &&
-            rail.settledUpTo >=
-            maxSettlementEpochForTerminatedRail(rail)
+            rail.settledUpTo >= maxSettlementEpochForTerminatedRail(rail)
         ) {
             finalizeTerminatedRail(rail, payer);
             return (amount, finalEpoch, finalizedNote);

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -166,20 +166,11 @@ contract Payments is
         approval.isApproved = true;
     }
 
-    function setOperatorApprovalStatus(
+
+    function setOperatorApproval(
         address token,
         address operator,
-        bool approved
-    ) external {
-        require(token != address(0), "token address cannot be zero");
-        require(operator != address(0), "operator address cannot be zero");
-
-        operatorApprovals[token][msg.sender][operator].isApproved = approved;
-    }
-
-    function setOperatorAllowances(
-        address token,
-        address operator,
+        bool    approved,
         uint256 rateAllowance,
         uint256 lockupAllowance
     ) external {
@@ -189,10 +180,13 @@ contract Payments is
         OperatorApproval storage approval = operatorApprovals[token][
             msg.sender
         ][operator];
+        
+        // Update approval status and allowances
+        approval.isApproved = approved;
         approval.rateAllowance = rateAllowance;
         approval.lockupAllowance = lockupAllowance;
     }
-
+    
     function terminateRail(
         uint256 railId
     ) external validateRailActive(railId) noRailModificationInProgress(railId) {

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -223,6 +223,71 @@ contract Payments is
         return railId;
     }
 
+    function terminateRail(
+        uint256 railId
+    ) external validateRailActive(railId) noRailModificationInProgress(railId) {
+        Rail storage rail = rails[railId];
+
+        // Ensure only the payer can terminate the rail
+        require(
+            rail.from == msg.sender,
+            "only the rail payer can terminate the rail"
+        );
+
+        Account storage payer = accounts[rail.token][rail.from];
+
+        // Settle account lockup
+        settleAccountLockup(payer);
+
+        // Check that the rail is not in debt
+        // (i.e., client has enough funds to pay for services already taken on this rail upto and including the current epoch)
+        require(
+            block.number < payer.lockupLastSettledAt + rail.lockupPeriod,
+            "rail is in debt; cannot terminate"
+        );
+
+        // Calculate the effective remaining lockup period that hasn't been settled
+        require(
+            payer.lockupLastSettledAt <= block.number,
+            "lockup settlement epoch cannot be in the future"
+        );
+        uint256 effectiveLockupPeriod = rail.lockupPeriod -
+            (block.number - payer.lockupLastSettledAt);
+
+        // Calculate funds that can be released (funds locked for future epochs + fixed lockup)
+        // note: this does not include the current epoch as the rail still needs to be paid for for the
+        // current epoch
+        uint256 fundsToRelease = (rail.paymentRate * effectiveLockupPeriod) +
+            rail.lockupFixed;
+
+        // Update payer's lockup rate and current lockup
+        require(
+            payer.lockupRate >= rail.paymentRate,
+            "payer lockup rate must be at least rail payment rate"
+        );
+        payer.lockupRate = payer.lockupRate - rail.paymentRate;
+
+        require(
+            payer.lockupCurrent >= fundsToRelease,
+            "payer lockup current must be at least funds to release"
+        );
+        payer.lockupCurrent = payer.lockupCurrent - fundsToRelease;
+
+        // Set rail payment rate and lockup period to 0 for future periods
+        rail.paymentRate = 0;
+        rail.lockupPeriod = 0;
+        rail.lockupFixed = 0;
+
+        // Mark rail as inactive
+        rail.isActive = false;
+
+        // Ensure account invariants hold
+        require(
+            payer.lockupCurrent <= payer.funds,
+            "payer lockup cannot exceed funds after termination"
+        );
+    }
+
     function modifyRailLockup(
         uint256 railId,
         uint256 period,

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -317,16 +317,10 @@ contract Payments is
         Rail storage rail = rails[railId];
 
         // Check if rail is terminated
-        if (rail.terminationEpoch > 0) {
-            require(
-                period == rail.lockupPeriod,
-                "cannot change lockup period on terminated rail"
-            );
-            require(
-                lockupFixed <= rail.lockupFixed,
-                "cannot increase fixed lockup on terminated rail"
-            );
-        }
+        require(
+            rail.terminationEpoch == 0 || (period == rail.lockupPeriod && lockupFixed <= rail.lockupFixed),
+            "failed to modify terminated rail: cannot change period or increase fixed lockup"
+        );
 
         Account storage payer = accounts[rail.token][rail.from];
         OperatorApproval storage approval = operatorApprovals[rail.token][
@@ -403,16 +397,10 @@ contract Payments is
         uint256 oldRate = rail.paymentRate;
 
         // For terminated rails, can only reduce rate, not increase it
-        if (rail.terminationEpoch > 0) {
-            require(
-                newRate <= oldRate,
-                "failed because terminated at epoch: cannot increase rate on terminated rail"
-            );
-            require(
-                oneTimePayment <= rail.lockupFixed,
-                "failed because terminated at epoch: one-time payment exceeds fixed lockup"
-            );
-        }
+        require(
+            rail.terminationEpoch == 0 || newRate <= oldRate,
+            "failed to modify rail: cannot increase rate on terminated rail"
+        );
 
         OperatorApproval storage approval = operatorApprovals[rail.token][
             rail.from

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -458,10 +458,6 @@ contract Payments is
         }
 
         // Calculate the effective lockup period (remaining period that hasn't been settled)
-        require(
-            payer.lockupLastSettledAt <= block.number,
-            "lockup settlement epoch cannot be in the future"
-        );
         uint256 effectiveLockupPeriod = rail.lockupPeriod -
             (block.number - payer.lockupLastSettledAt);
 

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -654,8 +654,7 @@ contract Payments is
             "one-time payment exceeds rail fixed lockup"
         );
 
-        // Calculate the original total lockup amount using effectiveLockupPeriod instead of rail.lockupPeriod
-        uint256 oldTotalLockup = (oldRate * effectiveLockupPeriod) +
+        uint256 oldTotalLockup = (oldRate * rail.lockupPeriod) +
             rail.lockupFixed;
         uint256 newTotalLockup = (newRate * effectiveLockupPeriod) +
             rail.lockupFixed;

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -347,11 +347,10 @@ contract Payments is
             rail.from
         ][rail.operator];
 
-        uint256 lockupSettledUpto = settleAccountLockup(payer);
-        require(
-            lockupSettledUpto == block.number,
-            "cannot modify terminated rail lockup: client has insufficient funds to cover current account lockup"
-        );
+        // we don't need to ensure that the account lockup is fully settled here
+        // because we already ensure that enough funds are locked for a terminated rail during
+        // `terminateRail`
+        settleAccountLockup(payer);
 
         // Calculate the fixed lockup reduction - this is the only change allowed for terminated rails
         uint256 lockupReduction = rail.lockupFixed - lockupFixed;
@@ -512,16 +511,6 @@ contract Payments is
             payer.lockupCurrent <= payer.funds,
             "invariant violation: payer lockup cannot exceed funds"
         );
-
-        // If we've reduced the rate, settle lockup again to account for changes
-        // and ensure that account lockup is settled upto and including the current epoch
-        if (newRate < oldRate) {
-            uint256 settledUpto = settleAccountLockup(payer);
-            require(
-                settledUpto == block.number,
-                "account lockup must be fully settled after rate decrease"
-            );
-        }
     }
 
     function handleRateChangeSettlement(

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -601,7 +601,6 @@ contract Payments is
                     maxSettlementEpochForTerminatedRail(railId, rail),
                 "terminated rail is beyond it's max settlement epoch; settle the rail"
             );
-
             require(
                 newRate <= oldRate,
                 "failed to modify rail: cannot increase rate on terminated rail"
@@ -753,11 +752,9 @@ contract Payments is
             return (
                 0,
                 startEpoch,
-                string(
-                    abi.encodePacked(
-                        "already settled up to maxSettlementEpoch epoch ",
-                        Strings.toString(maxSettlementEpoch)
-                    )
+                string.concat(
+                    "already settled up to epoch ",
+                    Strings.toString(maxSettlementEpoch)
                 )
             );
         }
@@ -800,11 +797,9 @@ contract Payments is
                     amount,
                     rail.settledUpTo,
                     segmentNote,
-                    string(
-                        abi.encodePacked(
-                            segmentNote,
-                            "terminated rail fully settled and finalized."
-                        )
+                    string.concat(
+                        segmentNote,
+                        "terminated rail fully settled and finalized."
                     )
                 );
         } else {
@@ -827,11 +822,9 @@ contract Payments is
                     settledAmount,
                     rail.settledUpTo,
                     settledNote,
-                    string(
-                        abi.encodePacked(
-                            settledNote,
-                            "terminated rail fully settled and finalized."
-                        )
+                    string.concat(
+                        settledNote,
+                        "terminated rail fully settled and finalized."
                     )
                 );
         }

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -415,7 +415,7 @@ contract Payments is
         // The client should first deposit enough funds to pay for this "debt" and then the rate can be changed.
         require(
             newRate == oldRate ||
-                block.number < payer.lockupLastSettledAt + rail.lockupPeriod,
+                block.number <= payer.lockupLastSettledAt + rail.lockupPeriod,
             "rail is in-debt; cannot change rate"
         );
 
@@ -447,7 +447,7 @@ contract Payments is
                 // by queueuing the previous rate only once
                 if (
                     rail.rateChangeQueue.isEmpty() ||
-                    rail.rateChangeQueue.peek().untilEpoch != block.number
+                    rail.rateChangeQueue.peekTail().untilEpoch != block.number
                 ) {
                     // For arbitrated rails, we need to enqueue the old rate.
                     // This ensures that the old rate is applied up to and including the current block.
@@ -964,8 +964,6 @@ contract Payments is
             // Round down to the nearest whole epoch
             uint256 fractionalEpochs = availableFunds / account.lockupRate;
             settledUpto = account.lockupLastSettledAt + fractionalEpochs;
-
-            //
             // Apply lockup up to this point
             account.lockupCurrent += account.lockupRate * fractionalEpochs;
             account.lockupLastSettledAt = settledUpto;

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -82,10 +82,6 @@ contract Payments is
     // token => owner => Account
     mapping(address => mapping(address => Account)) public accounts;
 
-    // client => operator => array of tokens
-    mapping(address => mapping(address => address[]))
-        public clientOperatorTokens;
-
     // railId => Rail
     mapping(uint256 => Rail) internal rails;
 
@@ -140,24 +136,17 @@ contract Payments is
         _;
     }
 
-    function terminateOperator(address operator) external {
+    function terminateOperator(address operator, address token) external {
         require(operator != address(0), "operator address cannot be zero");
+        require(token != address(0), "token address cannot be zero");
 
-        // Get tokens managed by this operator for the client
-        address[] memory tokens = clientOperatorTokens[msg.sender][operator];
-
-        // Iterate through all tokens and revoke permissions
-        for (uint256 i = 0; i < tokens.length; i++) {
-            address token = tokens[i];
-
-            // Set allowances to 0 and revoke approval
-            OperatorApproval storage approval = operatorApprovals[token][
-                msg.sender
+        // Revoke approval for the given token
+        OperatorApproval storage approval = operatorApprovals[token][
+            msg.sender
             ][operator];
-            approval.rateAllowance = 0;
-            approval.lockupAllowance = 0;
-            approval.isApproved = false;
-        }
+        approval.rateAllowance = 0;
+        approval.lockupAllowance = 0;
+        approval.isApproved = false;
     }
 
     function approveOperator(
@@ -175,19 +164,6 @@ contract Payments is
         approval.rateAllowance = rateAllowance;
         approval.lockupAllowance = lockupAllowance;
         approval.isApproved = true;
-
-        // Add token to the client's list of tokens for this operator if not already present
-        bool tokenExists = false;
-        address[] memory tokens = clientOperatorTokens[msg.sender][operator];
-        for (uint256 i = 0; i < tokens.length; i++) {
-            if (tokens[i] == token) {
-                tokenExists = true;
-                break;
-            }
-        }
-        if (!tokenExists) {
-            clientOperatorTokens[msg.sender][operator].push(token);
-        }
     }
 
     function setOperatorApprovalStatus(

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -227,11 +227,6 @@ contract Payments is
             "invariant violation: operator rate usage must be at least the rail payment rate"
         );
         approval.rateUsage -= rail.paymentRate;
-
-        require(
-            payer.lockupCurrent <= payer.funds,
-            "invariant violation: payer's current lockup cannot be greater than their funds"
-        );
     }
 
     function deposit(

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -151,19 +151,6 @@ contract Payments is
         _;
     }
 
-    function terminateOperator(address operator, address token) external {
-        require(operator != address(0), "operator address cannot be zero");
-        require(token != address(0), "token address cannot be zero");
-
-        // Revoke approval for the given token
-        OperatorApproval storage approval = operatorApprovals[token][
-            msg.sender
-            ][operator];
-        approval.rateAllowance = 0;
-        approval.lockupAllowance = 0;
-        approval.isApproved = false;
-    }
-
     function approveOperator(
         address token,
         address operator,

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -1001,7 +1001,7 @@ contract Payments is
     // returns the actual epoch upto and including which the lockup was settled
     function settleAccountLockup(
         Account storage account
-    ) internal returns (uint256 settledUpto) {
+    ) internal returns (uint256) {
         uint256 currentEpoch = block.number;
         uint256 elapsedTime = currentEpoch - account.lockupLastSettledAt;
 
@@ -1036,11 +1036,12 @@ contract Payments is
 
         // Round down to the nearest whole epoch
         uint256 fractionalEpochs = availableFunds / account.lockupRate;
-        settledUpto = account.lockupLastSettledAt + fractionalEpochs;
         // Apply lockup up to this point
         account.lockupCurrent += account.lockupRate * fractionalEpochs;
-        account.lockupLastSettledAt = settledUpto;
-        return settledUpto;
+        account.lockupLastSettledAt =
+            account.lockupLastSettledAt +
+            fractionalEpochs;
+        return account.lockupLastSettledAt;
     }
 
     function isRailTerminated(uint256 railId) public view returns (bool) {

--- a/src/RateChangeQueue.sol
+++ b/src/RateChangeQueue.sol
@@ -39,6 +39,13 @@ library RateChangeQueue {
         require(queue.head < queue.tail, "Queue is empty");
         return queue.changes[queue.head];
     }
+    
+    function peekTail(
+        Queue storage queue
+    ) internal view returns (RateChange memory) {
+        require(queue.head < queue.tail, "Queue is empty");
+        return queue.changes[queue.tail - 1];
+    }
 
     function isEmpty(Queue storage queue) internal view returns (bool) {
         return queue.head >= queue.tail;


### PR DESCRIPTION
- Enable client to terminate rail if rail is not in debt
- Allow operator to reduce rail rate if rail is not in debt and client has enough locked funds to settle the rail upto and including the current epoch.