### PR TITLE
invariants PR #1: allow operator to reduce lockup period and fixed lockup if rail is not in debt even if account is not fully settled and use only the nonreentrant modifier for reentrancy protection

### DIFF
--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -98,7 +98,10 @@ contract Payments is
     ) internal override onlyOwner {}
 
     modifier validateRailActive(uint256 railId) {
-        require(rails[railId].from != address(0), "rail does not exist or is inactive");
+        require(
+            rails[railId].from != address(0),
+            "rail does not exist or is inactive"
+        );
         _;
     }
 
@@ -1188,11 +1191,7 @@ contract Payments is
     ) internal view returns (bool) {
         return block.number > payer.lockupLastSettledAt + rail.lockupPeriod;
     }
-    
-    /**
-     * @dev Internal function to zero out all fields of a rail to mark it as inactive.
-     * Setting rail.from to address(0) is the main indicator that a rail is inactive.
-     */
+
     function _zeroOutRail(Rail storage rail) internal {
         rail.token = address(0);
         rail.from = address(0); // This now marks the rail as inactive
@@ -1204,7 +1203,7 @@ contract Payments is
         rail.lockupPeriod = 0;
         rail.settledUpTo = 0;
         rail.terminationEpoch = 0;
-        
+
         // Clear the rate change queue
         rail.rateChangeQueue.clear();
     }

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -100,7 +100,7 @@ contract Payments is
     modifier validateRailActive(uint256 railId) {
         require(
             rails[railId].from != address(0),
-            "rail does not exist or is inactive"
+            "rail does not exist or is beyond it's last settlement after termination"
         );
         _;
     }
@@ -308,7 +308,7 @@ contract Payments is
         if (isTerminated) {
             modifyTerminatedRailLockup(rail, period, lockupFixed);
         } else {
-            modifyActiveRailLockup(rail, period, lockupFixed);
+            modifyNonTerminatedRailLockup(rail, period, lockupFixed);
         }
     }
 
@@ -360,7 +360,7 @@ contract Payments is
         );
     }
 
-    function modifyActiveRailLockup(
+    function modifyNonTerminatedRailLockup(
         Rail storage rail,
         uint256 period,
         uint256 lockupFixed


### PR DESCRIPTION
Closes #14
Closes #27 
Closes #26 