### PR TITLE
Fix bugs discovered during testing PR #2: Allow Rail settlement and foreclosure

### DIFF
--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -827,7 +827,7 @@ contract Payments is
         // Handle terminated and fully settled rails that are still not finalised
         if (
             isRailTerminated(rail) &&
-            rail.settledUpTo >= maxSettlementEpochForTerminatedRail(rail)
+            rail.settledUpTo >= rail.endEpoch
         ) {
             finalizeTerminatedRail(rail, payer);
             return (0, rail.settledUpTo, "rail fully settled and finalized");
@@ -840,7 +840,7 @@ contract Payments is
         } else {
             maxSettlementEpoch = min(
                 untilEpoch,
-                maxSettlementEpochForTerminatedRail(rail)
+                rail.endEpoch
             );
         }
 

--- a/src/Payments.sol
+++ b/src/Payments.sol
@@ -836,7 +836,7 @@ contract Payments is
         // Calculate the maximum settlement epoch based on account lockup
         uint256 maxSettlementEpoch;
         if (!isRailTerminated(rail)) {
-            maxSettlementEpoch = payer.lockupLastSettledAt;
+            maxSettlementEpoch = min(untilEpoch, payer.lockupLastSettledAt);
         } else {
             maxSettlementEpoch = min(
                 untilEpoch,

--- a/test/PaymentsAccessControl.t.sol
+++ b/test/PaymentsAccessControl.t.sol
@@ -90,8 +90,11 @@ contract AccessControlTest is Test {
         vm.stopPrank();
     }
 
-    function testTerminateRail_SucceedsWhenCalledByRecipient() public {
+    function testTerminateRail_RevertsWhenCalledByRecipient() public {
         vm.startPrank(recipient);
+        vm.expectRevert(
+            "caller is not authorized: must be operator or client with settled lockup"
+        );
         payments.terminateRail(railId);
         vm.stopPrank();
     }
@@ -99,7 +102,7 @@ contract AccessControlTest is Test {
     function testTerminateRail_RevertsWhenCalledByUnauthorized() public {
         vm.startPrank(unauthorized);
         vm.expectRevert(
-            "failed to authorize: caller is not a rail participant"
+            "caller is not authorized: must be operator or client with settled lockup"
         );
         payments.terminateRail(railId);
         vm.stopPrank();
@@ -181,5 +184,29 @@ contract AccessControlTest is Test {
         vm.expectRevert("only the rail client can perform this action");
         payments.settleTerminatedRailWithoutArbitration(railId);
         vm.stopPrank();
+    }
+
+    function testTerminateRail_OnlyOperatorCanTerminateWhenLockupNotFullySettled()
+        public
+    {
+        // Advance blocks to create an unsettled state
+        helper.advanceBlocks(500);
+
+        // Client should not be able to terminate because lockup is not fully settled
+        vm.startPrank(client);
+        vm.expectRevert(
+            "caller is not authorized: must be operator or client with settled lockup"
+        );
+        payments.terminateRail(railId);
+        vm.stopPrank();
+
+        // Operator should be able to terminate even when lockup is not fully settled
+        vm.startPrank(operator);
+        payments.terminateRail(railId);
+        vm.stopPrank();
+
+        // Verify the rail was terminated by checking its end epoch is set
+        Payments.RailView memory railView = payments.getRail(railId);
+        assertTrue(railView.endEpoch > 0, "Rail was not terminated properly");
     }
 }


### PR DESCRIPTION
@Stebalien 

- I don't think we should allow people to withdraw the rail lockup during normal settlement. It messes up all of our accounting. When you settle a rail in the normal cause of events, you can only withdraw upto and including the account lockup.

- If you want to withdraw the rail "future" lockup as well (might not be the "future" for a rail in debt) -> you should foreclose the rail and be done with it as you are essentially saying that you don't trust the client to deposit more funds anyways.